### PR TITLE
add option for manual salt on deploy

### DIFF
--- a/src/subcommands/deploy.rs
+++ b/src/subcommands/deploy.rs
@@ -51,6 +51,8 @@ pub struct Deploy {
     )]
     estimate_only: bool,
     #[clap(long, help = "Wait for the transaction to confirm")]
+    salt: Option<String>,
+    #[clap(long, help = "Use the given salt to pre-compute contract deploy address")]
     watch: bool,
     #[clap(help = "Class hash")]
     class_hash: String,
@@ -73,8 +75,11 @@ impl Deploy {
             ctor_args.append(&mut felt_decoder.decode(element).await?);
         }
 
-        // TODO: add option for manually setting salt
-        let salt = SigningKey::from_random().secret_scalar();
+        let salt = if let Some(s) = self.salt {
+            FieldElement::from_hex_be(&s)?
+        } else {
+            SigningKey::from_random().secret_scalar()
+        };
 
         // TODO: refactor account & signer loading
 


### PR DESCRIPTION
As seen in comments inside the `deploy` subcommand code, it can be useful to manually provide the `salt`.

I just went over a case where it's very useful, deploying contracts for testing where a constant address may ease the tests.