### PR TITLE
feat(starkliup): install specific version

### DIFF
--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -72,16 +72,12 @@ main() {
 }
 
 install() {
-    local release_path
-
-    if [[ $RELEASE_TAG == *"latest"* ]]; then
+    if [ $RELEASE_TAG = "latest" ]; then
         echo "Installing the latest version of starkli..."
         echo "Fetching the latest release tag from GitHub..."
         RELEASE_TAG="$(curl -s "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
-        release_path="latest"
     else
         echo "Installing version ${RELEASE_TAG}..."
-        release_path="tags/${RELEASE_TAG}"
     fi
 
     detect_host_triple
@@ -113,11 +109,9 @@ install() {
 download_release_file() {
     echo "Downloading release file from GitHub..."
     if command -v curl >/dev/null 2>&1; then
-        local http_code
-
-        http_code="$(curl -# -L "$FILE_URL" -o "$TEMP_FILE_NAME" --write-out "%{http_code}")"
-        if [ "$http_code" -ne 200 ]; then
-            echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub [${http_code}].${normal}"
+        HTTP_CODE="$(curl -# -L "$FILE_URL" -o "$TEMP_FILE_NAME" --write-out "%{http_code}")"
+        if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub [${HTTP_CODE}].${normal}"
             exit 1
         fi
     else

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -45,7 +45,6 @@ main() {
                 usage
                 exit 0
                 ;;
-
             -v|--version)
                 if [ $# -gt 1 ]; then
                     RELEASE_TAG="$2"

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -80,7 +80,7 @@ install() {
         RELEASE_TAG="$(curl -s "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
         release_path="latest"
     else
-        echo "Installing version ${RELEASE_TAG}"
+        echo "Installing version ${RELEASE_TAG}..."
         release_path="tags/${RELEASE_TAG}"
     fi
 
@@ -113,6 +113,8 @@ install() {
 download_release_file() {
     echo "Downloading release file from GitHub..."
     if command -v curl >/dev/null 2>&1; then
+        local http_code
+
         http_code="$(curl -# -L "$FILE_URL" -o "$TEMP_FILE_NAME" --write-out "%{http_code}")"
         if [ "$http_code" -ne 200 ]; then
             echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub [${http_code}].${normal}"

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -92,7 +92,6 @@ install() {
     fi
 
     echo "Detected host triple: ${cyan}${TRIPLE}${normal}"
-    echo "Downloading release file from GitHub..."
 
     FILE_NAME="starkli-${TRIPLE}.tar.gz"
     FILE_URL="https://github.com/xJonathanLEI/starkli/releases/download/${RELEASE_TAG}/${FILE_NAME}"
@@ -112,6 +111,7 @@ install() {
 }
 
 download_release_file() {
+    echo "Downloading release file from GitHub..."
     if command -v curl >/dev/null 2>&1; then
         http_code="$(curl -# -L "$FILE_URL" -o "$TEMP_FILE_NAME" --write-out "%{http_code}")"
         if [ "$http_code" -ne 200 ]; then
@@ -119,8 +119,7 @@ download_release_file() {
             exit 1
         fi
     elif command -v wget >/dev/null 2>&1; then
-        wget -q --show-progress -O "$TEMP_FILE_NAME" "$FILE_URL"
-        if [ "$?" -ne 0 ]; then
+        if ! wget -q --show-progress -O "$TEMP_FILE_NAME" "$FILE_URL"; then
             echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub.${normal}"
             exit 1
         fi

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -14,7 +14,7 @@ STARKLI_BIN_PATH="${STARKLI_BIN_DIR}/starkli"
 
 # This MUST be updated whenever this file is changed.
 # TODO: add CI check to ensure this.
-STARKLIUP_VERSION="2023-06-25"
+STARKLIUP_VERSION="2023-07-21"
 
 # Fancy color setup:
 #   https://unix.stackexchange.com/questions/9957/how-to-check-if-bash-can-print-colors
@@ -47,7 +47,14 @@ main() {
                 ;;
             -v|--version)
                 if [ $# -gt 1 ]; then
-                    RELEASE_TAG="$2"
+                    case $2 in
+                        "v"*)
+                            RELEASE_TAG="$2"
+                        ;;
+                        *)
+                            RELEASE_TAG="v$2"
+                        ;;
+                    esac
                     shift
                 else
                     echo "${red}Version tag is missing${normal}" 1>&2

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -37,33 +37,54 @@ if test -t 1; then
 fi
 
 main() {
-    if [ -z "$1" ]; then
-        install
-        echo
-        completions
+    RELEASE_TAG=latest
 
-        echo
-        echo "Installation successfully completed."
-    else
-        case $1 in
+    while [ $# -gt 0 ]; do
+        case "$1" in
             -h|--help)
                 usage
                 exit 0
+                ;;
+
+            -v|--version)
+                if [ $# -gt 1 ]; then
+                    RELEASE_TAG="$2"
+                    shift
+                else
+                    echo "${red}Version tag is missing${normal}" 1>&2
+                    exit 1
+                fi
                 ;;
             *)
                 echo "${red}Unknown option: $1${normal}" 1>&2
                 echo "Run ${yellow}starkliup --help${normal} to see usage." 1>&2
                 exit 1
+                ;;
         esac
-    fi
+        shift
+    done
+
+    install
+    echo
+    completions
+
+    echo
+    echo "Installation successfully completed."
 }
 
 install() {
-    echo "Installing the latest version of starkli..."
+    local release_path
 
-    echo "Fetching the latest release from GitHub..."
-    LATEST_TAG="$(curl -# "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
-    echo "Latest release found: ${yellow}${LATEST_TAG}${normal}"
+    if [[ $RELEASE_TAG == *"latest"* ]]; then
+        echo "Installing the latest version of starkli..."
+        echo "Fetching the latest release from GitHub..."
+        RELEASE_TAG="$(curl -# "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
+        release_path="latest"
+    else
+        echo "Installing version ${RELEASE_TAG}"
+        echo "Fetching release ${RELEASE_TAG} from GitHub..."
+        release_path="tags/${RELEASE_TAG}"
+    fi
 
     detect_host_triple
     if [ -z "$TRIPLE" ]; then
@@ -72,16 +93,16 @@ install() {
     fi
 
     echo "Detected host triple: ${cyan}${TRIPLE}${normal}"
-    echo "Downloading latest release from GitHub..."
+    echo "Downloading release file from GitHub..."
 
     FILE_NAME="starkli-${TRIPLE}.tar.gz"
-    FILE_URL="https://github.com/xJonathanLEI/starkli/releases/download/${LATEST_TAG}/${FILE_NAME}"
+    FILE_URL="https://github.com/xJonathanLEI/starkli/releases/download/${RELEASE_TAG}/${FILE_NAME}"
 
     TEMP_DIR="$(mktemp -d)"
     TEMP_FILE_NAME="${TEMP_DIR}/${FILE_NAME}"
 
-    # TODO: support wget if curl is not found
-    curl -# -L $FILE_URL -o $TEMP_FILE_NAME
+    download_release_file
+
     tar zxf $TEMP_FILE_NAME -C $TEMP_DIR
 
     mv "${TEMP_DIR}/starkli" "${STARKLI_BIN_PATH}"
@@ -89,6 +110,25 @@ install() {
     rm -rf $TEMP_DIR
 
     echo "Successfully installed starkli ${yellow}${LATEST_TAG}${normal}"
+}
+
+download_release_file() {
+    if command -v curl >/dev/null 2>&1; then
+        http_code="$(curl -# -L "$FILE_URL" -o "$TEMP_FILE_NAME" --write-out "%{http_code}")"
+        if [ "$http_code" -ne 200 ]; then
+            echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub [${http_code}].${normal}"
+            exit 1
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q --show-progress -O "$TEMP_FILE_NAME" "$FILE_URL"
+        if [ "$?" -ne 0 ]; then
+            echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub.${normal}"
+            exit 1
+        fi
+    else
+        echo "${red}Command 'curl' or 'wget' is required.${normal}"
+        exit 1
+    fi
 }
 
 completions() {

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -118,11 +118,6 @@ download_release_file() {
             echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub [${http_code}].${normal}"
             exit 1
         fi
-    elif command -v wget >/dev/null 2>&1; then
-        if ! wget -q --show-progress -O "$TEMP_FILE_NAME" "$FILE_URL"; then
-            echo "${red}Couldn't download release file for tag '${RELEASE_TAG}' from GitHub.${normal}"
-            exit 1
-        fi
     else
         echo "${red}Command 'curl' or 'wget' is required.${normal}"
         exit 1

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -99,6 +99,7 @@ install() {
     TEMP_DIR="$(mktemp -d)"
     TEMP_FILE_NAME="${TEMP_DIR}/${FILE_NAME}"
 
+    # TODO: support wget if curl is not found
     download_release_file
 
     tar zxf $TEMP_FILE_NAME -C $TEMP_DIR
@@ -119,7 +120,7 @@ download_release_file() {
             exit 1
         fi
     else
-        echo "${red}Command 'curl' or 'wget' is required.${normal}"
+        echo "${red}Command 'curl' is required.${normal}"
         exit 1
     fi
 }

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -77,12 +77,11 @@ install() {
 
     if [[ $RELEASE_TAG == *"latest"* ]]; then
         echo "Installing the latest version of starkli..."
-        echo "Fetching the latest release from GitHub..."
-        RELEASE_TAG="$(curl -# "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
+        echo "Fetching the latest release tag from GitHub..."
+        RELEASE_TAG="$(curl -s "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
         release_path="latest"
     else
         echo "Installing version ${RELEASE_TAG}"
-        echo "Fetching release ${RELEASE_TAG} from GitHub..."
         release_path="tags/${RELEASE_TAG}"
     fi
 

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -199,6 +199,7 @@ USAGE:
 
 OPTIONS:
     -h, --help      Print this message
+    -v, --version   The version of starkli to install
 EOF
 }
 

--- a/starkliup/starkliup
+++ b/starkliup/starkliup
@@ -83,8 +83,9 @@ install() {
         echo "Installing the latest version of starkli..."
         echo "Fetching the latest release tag from GitHub..."
         RELEASE_TAG="$(curl -s "https://api.github.com/repos/xJonathanLEI/starkli/releases/latest" | grep "tag_name" | cut -d \" -f 4)"
+        echo "Latest version found: ${yellow}${RELEASE_TAG}${normal}"
     else
-        echo "Installing version ${RELEASE_TAG}..."
+        echo "Installing version ${yellow}${RELEASE_TAG}${normal}..."
     fi
 
     detect_host_triple


### PR DESCRIPTION
The current PR is motivated by the fact that different versions may propose different compiler versions, and the versions are not exhaustive as we depend on the `cairo-starknet-xxx` versioning.

This PR proposes the use of `-v|--version` option + add fallback to `wget` if curl is not supported.

The proposed behavior is the following:

```bash
# As before, by default the latest version if fetched and installed.
$ starkliup

# Specifying a tag, which will fail if the tag is invalid.
$ starkliup --version v0.1.1
$ starkliup -v v0.1.1

# This is supported too.
$ starkliup -v latest 
```

We can remove the `v` and only ask the use `0.1.2` for instance.

@xJonathanLEI WDYT?