### PR TITLE
feat: add max-fee support

### DIFF
--- a/src/subcommands/account/deploy.rs
+++ b/src/subcommands/account/deploy.rs
@@ -25,6 +25,11 @@ pub struct Deploy {
     signer: SignerArgs,
     #[clap(
         long,
+        help = "Maximum fee to pay for the transaction"
+    )]
+    max_fee: Option<FieldElement>,
+    #[clap(
+        long,
         help = "Only estimate transaction fee without sending transaction"
     )]
     estimate_only: bool,
@@ -117,9 +122,15 @@ impl Deploy {
         eprint!("Press [ENTER] once you've funded the address.");
         std::io::stdin().read_line(&mut String::new())?;
 
+        let max_fee = if let Some(max_fee) = self.max_fee {
+            max_fee
+        } else {
+            estimated_fee_with_buffer
+        };
+
         // TODO: add option to check ETH balance before sending out tx
         let account_deployment_tx = account_deployment
-            .max_fee(estimated_fee_with_buffer)
+            .max_fee(max_fee)
             .send()
             .await?
             .transaction_hash;

--- a/src/subcommands/account/deploy.rs
+++ b/src/subcommands/account/deploy.rs
@@ -23,10 +23,7 @@ pub struct Deploy {
     provider: ProviderArgs,
     #[clap(flatten)]
     signer: SignerArgs,
-    #[clap(
-        long,
-        help = "Maximum fee to pay for the transaction"
-    )]
+    #[clap(long, help = "Maximum fee to pay for the transaction")]
     max_fee: Option<FieldElement>,
     #[clap(
         long,

--- a/src/subcommands/declare.rs
+++ b/src/subcommands/declare.rs
@@ -28,10 +28,7 @@ pub struct Declare {
     signer: SignerArgs,
     #[clap(flatten)]
     casm: CasmArgs,
-    #[clap(
-        long,
-        help = "Maximum fee to pay for the transaction"
-    )]
+    #[clap(long, help = "Maximum fee to pay for the transaction")]
     max_fee: Option<FieldElement>,
     #[clap(
         long,
@@ -164,9 +161,7 @@ impl Declare {
 
             // TODO: make buffer configurable
             let declaration = if let Some(max_fee) = self.max_fee {
-                account
-                    .declare_legacy(Arc::new(class))
-                    .max_fee(max_fee)
+                account.declare_legacy(Arc::new(class)).max_fee(max_fee)
             } else {
                 account
                     .declare_legacy(Arc::new(class))

--- a/src/subcommands/declare.rs
+++ b/src/subcommands/declare.rs
@@ -30,6 +30,11 @@ pub struct Declare {
     casm: CasmArgs,
     #[clap(
         long,
+        help = "Maximum fee to pay for the transaction"
+    )]
+    max_fee: Option<FieldElement>,
+    #[clap(
+        long,
         env = "STARKNET_ACCOUNT",
         help = "Path to account config JSON file"
     )]
@@ -114,9 +119,15 @@ impl Declare {
             }
 
             // TODO: make buffer configurable
-            let declaration = account
-                .declare(Arc::new(class.flatten()?), casm_class_hash)
-                .fee_estimate_multiplier(1.5f64);
+            let declaration = if let Some(max_fee) = self.max_fee {
+                account
+                    .declare(Arc::new(class.flatten()?), casm_class_hash)
+                    .max_fee(max_fee)
+            } else {
+                account
+                    .declare(Arc::new(class.flatten()?), casm_class_hash)
+                    .fee_estimate_multiplier(1.5f64)
+            };
 
             if self.estimate_only {
                 let estimated_fee = declaration.estimate_fee().await?.overall_fee;
@@ -152,9 +163,15 @@ impl Declare {
             }
 
             // TODO: make buffer configurable
-            let declaration = account
-                .declare_legacy(Arc::new(class))
-                .fee_estimate_multiplier(1.5f64);
+            let declaration = if let Some(max_fee) = self.max_fee {
+                account
+                    .declare_legacy(Arc::new(class))
+                    .max_fee(max_fee)
+            } else {
+                account
+                    .declare_legacy(Arc::new(class))
+                    .fee_estimate_multiplier(1.5f64)
+            };
 
             if self.estimate_only {
                 let estimated_fee = declaration.estimate_fee().await?.overall_fee;

--- a/src/subcommands/invoke.rs
+++ b/src/subcommands/invoke.rs
@@ -27,10 +27,7 @@ pub struct Invoke {
     provider: ProviderArgs,
     #[clap(flatten)]
     signer: SignerArgs,
-    #[clap(
-        long,
-        help = "Maximum fee to pay for the transaction"
-    )]
+    #[clap(long, help = "Maximum fee to pay for the transaction")]
     max_fee: Option<FieldElement>,
     #[clap(
         long,


### PR DESCRIPTION
Currently, we're encouraging users to use `--rpc`. However, using `alchemy` and `infura` since the `v0.12` the transactions fail very frequently due to `FeeTransferError`:

```bash
PY_TRANSACTION_EXECUTION_ERROR
Transaction from sender address 0x7c0ea427ddca72a6bdd66746e9c0c0651e5eac76977ab9b7bbf796a410f8929 has failed.
FeeTransferError { max_fee: Fee(1899000516528), actual_fee: Fee(2490000677280) }
```

So the multiplier `1.5` is not enough in that case.
Is that due to latency? To the missing `pending` state in the `v0.12` which is causing this?

To allow users not be dependent on that, this PR adds `max-fee` support for `declare, deploy, invoke and account deploy`.