### PR TITLE
feat: add `2.4.0` compiler version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,10 +360,26 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-utils 2.1.0",
+ "indoc",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "parity-scale-codec",
+ "parity-scale-codec-derive",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-casm"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.4.0",
  "indoc",
  "num-bigint",
  "num-traits 0.2.16",
@@ -376,21 +392,45 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "anyhow",
+ "cairo-lang-defs 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-lowering 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-plugins 2.1.0",
+ "cairo-lang-project 2.1.0",
+ "cairo-lang-semantic 2.1.0",
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-sierra-generator 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "log",
+ "salsa",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-compiler"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "anyhow",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-lowering",
- "cairo-lang-parser",
- "cairo-lang-project",
- "cairo-lang-semantic",
- "cairo-lang-sierra",
- "cairo-lang-sierra-generator",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-defs 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-lowering 2.4.0",
+ "cairo-lang-parser 2.4.0",
+ "cairo-lang-project 2.4.0",
+ "cairo-lang-semantic 2.4.0",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-sierra-generator 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "itertools 0.11.0",
  "salsa",
  "thiserror",
@@ -398,10 +438,35 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-utils 2.1.0",
+]
+
+[[package]]
+name = "cairo-lang-debug"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.4.0",
+]
+
+[[package]]
+name = "cairo-lang-defs"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "indexmap 2.1.0",
+ "itertools 0.11.0",
+ "salsa",
+ "smol_str",
 ]
 
 [[package]]
@@ -409,12 +474,12 @@ name = "cairo-lang-defs"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-parser",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-parser 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "itertools 0.11.0",
  "salsa",
  "smol_str",
@@ -422,12 +487,35 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "itertools 0.11.0",
+ "salsa",
+]
+
+[[package]]
+name = "cairo-lang-diagnostics"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-filesystem",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-utils 2.4.0",
+ "itertools 0.11.0",
+]
+
+[[package]]
+name = "cairo-lang-eq-solver"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-utils 2.1.0",
+ "good_lp",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
 ]
 
@@ -436,8 +524,21 @@ name = "cairo-lang-eq-solver"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.4.0",
  "good_lp",
+]
+
+[[package]]
+name = "cairo-lang-filesystem"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "path-clean",
+ "salsa",
+ "serde",
+ "smol_str",
 ]
 
 [[package]]
@@ -445,8 +546,8 @@ name = "cairo-lang-filesystem"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "path-clean",
  "salsa",
  "serde",
@@ -455,18 +556,42 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-defs 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-proc-macros 2.1.0",
+ "cairo-lang-semantic 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "id-arena",
+ "indexmap 2.1.0",
+ "itertools 0.11.0",
+ "log",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "salsa",
+ "smol_str",
+]
+
+[[package]]
+name = "cairo-lang-lowering"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-parser",
- "cairo-lang-proc-macros",
- "cairo-lang-semantic",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-defs 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-parser 2.4.0",
+ "cairo-lang-proc-macros 2.4.0",
+ "cairo-lang-semantic 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "id-arena",
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -480,14 +605,34 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-syntax-codegen 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "colored",
+ "itertools 0.11.0",
+ "log",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "salsa",
+ "smol_str",
+ "unescaper",
+]
+
+[[package]]
+name = "cairo-lang-parser"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-syntax",
- "cairo-lang-syntax-codegen",
- "cairo-lang-utils",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-syntax-codegen 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "colored",
  "itertools 0.11.0",
  "num-bigint",
@@ -499,15 +644,34 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-defs 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-semantic 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "indoc",
+ "itertools 0.11.0",
+ "num-bigint",
+ "salsa",
+ "smol_str",
+]
+
+[[package]]
+name = "cairo-lang-plugins"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-parser",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-defs 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-parser 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "indent",
  "indoc",
  "itertools 0.11.0",
@@ -517,12 +681,35 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "cairo-lang-proc-macros"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
+ "cairo-lang-debug 2.4.0",
  "quote",
  "syn 2.0.41",
+]
+
+[[package]]
+name = "cairo-lang-project"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "serde",
+ "smol_str",
+ "thiserror",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -530,12 +717,34 @@ name = "cairo-lang-project"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-filesystem",
- "cairo-lang-utils",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "serde",
  "smol_str",
  "thiserror",
- "toml",
+ "toml 0.8.8",
+]
+
+[[package]]
+name = "cairo-lang-semantic"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-defs 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-proc-macros 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "id-arena",
+ "itertools 0.11.0",
+ "log",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "salsa",
+ "smol_str",
 ]
 
 [[package]]
@@ -543,15 +752,15 @@ name = "cairo-lang-semantic"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-parser",
- "cairo-lang-plugins",
- "cairo-lang-proc-macros",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-defs 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-parser 2.4.0",
+ "cairo-lang-plugins 2.4.0",
+ "cairo-lang-proc-macros 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "id-arena",
  "indoc",
  "itertools 0.11.0",
@@ -564,11 +773,33 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-utils 2.1.0",
+ "const-fnv1a-hash",
+ "convert_case",
+ "derivative",
+ "itertools 0.11.0",
+ "lalrpop",
+ "lalrpop-util",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "regex",
+ "salsa",
+ "serde",
+ "sha3",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "anyhow",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.4.0",
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
@@ -588,13 +819,39 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-eq-solver 2.1.0",
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-sierra-type-size 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "itertools 0.11.0",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra-ap-change"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-eq-solver",
- "cairo-lang-sierra",
- "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-eq-solver 2.4.0",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-sierra-type-size 2.4.0",
+ "cairo-lang-utils 2.4.0",
+ "itertools 0.11.0",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra-gas"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-eq-solver 2.1.0",
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-sierra-type-size 2.1.0",
+ "cairo-lang-utils 2.1.0",
  "itertools 0.11.0",
  "thiserror",
 ]
@@ -604,12 +861,37 @@ name = "cairo-lang-sierra-gas"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-eq-solver",
- "cairo-lang-sierra",
- "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-eq-solver 2.4.0",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-sierra-type-size 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "itertools 0.11.0",
  "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra-generator"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-defs 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-lowering 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-plugins 2.1.0",
+ "cairo-lang-proc-macros 2.1.0",
+ "cairo-lang-semantic 2.1.0",
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "id-arena",
+ "indexmap 2.1.0",
+ "itertools 0.11.0",
+ "num-bigint",
+ "salsa",
+ "smol_str",
 ]
 
 [[package]]
@@ -617,16 +899,16 @@ name = "cairo-lang-sierra-generator"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-lowering",
- "cairo-lang-parser",
- "cairo-lang-semantic",
- "cairo-lang-sierra",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-defs 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-lowering 2.4.0",
+ "cairo-lang-parser 2.4.0",
+ "cairo-lang-semantic 2.4.0",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "indexmap 2.1.0",
  "itertools 0.11.0",
  "num-bigint",
@@ -637,17 +919,38 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "assert_matches",
+ "cairo-felt",
+ "cairo-lang-casm 2.1.0",
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-sierra-ap-change 2.1.0",
+ "cairo-lang-sierra-gas 2.1.0",
+ "cairo-lang-sierra-type-size 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "indoc",
+ "itertools 0.11.0",
+ "log",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra-to-casm"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "assert_matches",
  "cairo-felt",
- "cairo-lang-casm",
- "cairo-lang-sierra",
- "cairo-lang-sierra-ap-change",
- "cairo-lang-sierra-gas",
- "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-casm 2.4.0",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-sierra-ap-change 2.4.0",
+ "cairo-lang-sierra-gas 2.4.0",
+ "cairo-lang-sierra-type-size 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "indoc",
  "itertools 0.11.0",
  "num-bigint",
@@ -657,11 +960,60 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-utils 2.1.0",
+]
+
+[[package]]
+name = "cairo-lang-sierra-type-size"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-sierra",
- "cairo-lang-utils",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-utils 2.4.0",
+]
+
+[[package]]
+name = "cairo-lang-starknet"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "anyhow",
+ "cairo-felt",
+ "cairo-lang-casm 2.1.0",
+ "cairo-lang-compiler 2.1.0",
+ "cairo-lang-defs 2.1.0",
+ "cairo-lang-diagnostics 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-lowering 2.1.0",
+ "cairo-lang-parser 2.1.0",
+ "cairo-lang-plugins 2.1.0",
+ "cairo-lang-semantic 2.1.0",
+ "cairo-lang-sierra 2.1.0",
+ "cairo-lang-sierra-ap-change 2.1.0",
+ "cairo-lang-sierra-gas 2.1.0",
+ "cairo-lang-sierra-generator 2.1.0",
+ "cairo-lang-sierra-to-casm 2.1.0",
+ "cairo-lang-syntax 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "convert_case",
+ "genco",
+ "indent",
+ "indoc",
+ "itertools 0.11.0",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.16",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "sha3",
+ "smol_str",
+ "thiserror",
 ]
 
 [[package]]
@@ -671,18 +1023,18 @@ source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d
 dependencies = [
  "anyhow",
  "cairo-felt",
- "cairo-lang-casm",
- "cairo-lang-compiler",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-lowering",
- "cairo-lang-semantic",
- "cairo-lang-sierra",
- "cairo-lang-sierra-generator",
- "cairo-lang-sierra-to-casm",
- "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-casm 2.4.0",
+ "cairo-lang-compiler 2.4.0",
+ "cairo-lang-defs 2.4.0",
+ "cairo-lang-diagnostics 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-lowering 2.4.0",
+ "cairo-lang-semantic 2.4.0",
+ "cairo-lang-sierra 2.4.0",
+ "cairo-lang-sierra-generator 2.4.0",
+ "cairo-lang-sierra-to-casm 2.4.0",
+ "cairo-lang-syntax 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "const_format",
  "convert_case",
  "indent",
@@ -702,12 +1054,28 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "cairo-lang-debug 2.1.0",
+ "cairo-lang-filesystem 2.1.0",
+ "cairo-lang-utils 2.1.0",
+ "num-bigint",
+ "num-traits 0.2.16",
+ "salsa",
+ "smol_str",
+ "thiserror",
+ "unescaper",
+]
+
+[[package]]
+name = "cairo-lang-syntax"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "cairo-lang-debug",
- "cairo-lang-filesystem",
- "cairo-lang-utils",
+ "cairo-lang-debug 2.4.0",
+ "cairo-lang-filesystem 2.4.0",
+ "cairo-lang-utils 2.4.0",
  "num-bigint",
  "num-traits 0.2.16",
  "salsa",
@@ -717,11 +1085,35 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "genco",
+ "xshell",
+]
+
+[[package]]
+name = "cairo-lang-syntax-codegen"
 version = "2.4.0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "genco",
  "xshell",
+]
+
+[[package]]
+name = "cairo-lang-utils"
+version = "2.1.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+dependencies = [
+ "indexmap 2.1.0",
+ "itertools 0.11.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.16",
+ "parity-scale-codec",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -2859,7 +3251,8 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bigdecimal 0.4.1",
- "cairo-lang-starknet",
+ "cairo-lang-starknet 2.1.0",
+ "cairo-lang-starknet 2.4.0",
  "chrono",
  "clap",
  "clap_complete",
@@ -3324,6 +3717,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
@@ -3341,6 +3746,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "ark-ff"
@@ -200,7 +200,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -360,8 +360,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -376,8 +376,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -385,31 +385,29 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
  "cairo-lang-parser",
- "cairo-lang-plugins",
  "cairo-lang-project",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
  "cairo-lang-sierra-generator",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "log",
+ "itertools 0.11.0",
  "salsa",
- "smol_str",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -417,7 +415,6 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "indexmap 2.0.0",
  "itertools 0.11.0",
  "salsa",
  "smol_str",
@@ -425,31 +422,28 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "itertools 0.11.0",
- "salsa",
 ]
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
- "indexmap 2.0.0",
- "itertools 0.11.0",
 ]
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -461,8 +455,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -474,19 +468,20 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
+ "once_cell",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -495,7 +490,6 @@ dependencies = [
  "cairo-lang-utils",
  "colored",
  "itertools 0.11.0",
- "log",
  "num-bigint",
  "num-traits 0.2.16",
  "salsa",
@@ -505,37 +499,36 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
- "cairo-lang-semantic",
  "cairo-lang-syntax",
  "cairo-lang-utils",
+ "indent",
  "indoc",
  "itertools 0.11.0",
- "num-bigint",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -547,31 +540,34 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
+ "cairo-lang-plugins",
  "cairo-lang-proc-macros",
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
+ "indoc",
  "itertools 0.11.0",
- "log",
  "num-bigint",
  "num-traits 0.2.16",
+ "once_cell",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
+ "anyhow",
  "cairo-lang-utils",
  "const-fnv1a-hash",
  "convert_case",
@@ -584,6 +580,7 @@ dependencies = [
  "regex",
  "salsa",
  "serde",
+ "serde_json",
  "sha3",
  "smol_str",
  "thiserror",
@@ -591,8 +588,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -604,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -617,8 +614,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -626,24 +623,22 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
  "cairo-lang-parser",
- "cairo-lang-plugins",
- "cairo-lang-proc-macros",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "id-arena",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
  "num-bigint",
+ "once_cell",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -655,7 +650,6 @@ dependencies = [
  "cairo-lang-utils",
  "indoc",
  "itertools 0.11.0",
- "log",
  "num-bigint",
  "num-traits 0.2.16",
  "thiserror",
@@ -663,8 +657,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -672,8 +666,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -683,22 +677,17 @@ dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
- "cairo-lang-parser",
- "cairo-lang-plugins",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
- "cairo-lang-sierra-ap-change",
- "cairo-lang-sierra-gas",
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-syntax",
  "cairo-lang-utils",
+ "const_format",
  "convert_case",
- "genco",
  "indent",
  "indoc",
  "itertools 0.11.0",
- "log",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.16",
@@ -707,13 +696,14 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
+ "starknet-crypto 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -722,14 +712,13 @@ dependencies = [
  "num-traits 0.2.16",
  "salsa",
  "smol_str",
- "thiserror",
  "unescaper",
 ]
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
  "genco",
  "xshell",
@@ -737,13 +726,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.1.0#0f77760aa2e7750b2dda7e708403584e3040b6ad"
+version = "2.4.0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.4.0#a4de08fbd75fa1d58c69d054d6b3d99aaf318f90"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
  "num-bigint",
- "num-integer",
  "num-traits 0.2.16",
  "parity-scale-codec",
  "schemars",
@@ -833,7 +821,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -876,6 +864,26 @@ name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -1010,7 +1018,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1021,7 +1029,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1299,7 +1307,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1330,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "genco"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6973ce8518068a71d404f428f6a5b563088545546a6bd8f9c0a7f2608149bc8a"
+checksum = "98d7af598790738fee616426e669360fa361273b1b9c9b7f30c92fa627605cad"
 dependencies = [
  "genco-macros",
  "relative-path",
@@ -1341,13 +1349,13 @@ dependencies = [
 
 [[package]]
 name = "genco-macros"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2c778cf01917d0fbed53900259d6604a421fab4916a2e738856ead9f1d926a"
+checksum = "d4cf186fea4af17825116f72932fe52cce9a13bae39ff63b4dc0cfdb3fb4bde1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1394,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0833c2bc3cee9906df9969ade12b0b3b8759faa7bc2682b428be767033cdcd4"
+checksum = "fa124423ded10046a849fa0ae9747c541895557f1af177e0890b09879e7e9e7d"
 dependencies = [
  "fnv",
  "minilp",
@@ -1429,9 +1437,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -1655,20 +1663,20 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inout"
@@ -2032,9 +2040,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.4"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
+checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2046,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.4"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
+checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2201,12 +2209,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "once_cell",
- "toml_edit",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -2235,18 +2242,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2597,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
@@ -2610,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2656,22 +2663,22 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2691,7 +2698,7 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -2710,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -2754,7 +2761,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2888,8 +2895,8 @@ dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
- "starknet-crypto",
- "starknet-ff",
+ "starknet-crypto 0.6.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "starknet-macros",
  "starknet-providers",
  "starknet-signers",
@@ -2935,8 +2942,28 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto",
- "starknet-ff",
+ "starknet-crypto 0.6.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.16",
+ "rfc6979",
+ "sha2",
+ "starknet-crypto-codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-curve 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize",
 ]
 
 [[package]]
@@ -2952,10 +2979,21 @@ dependencies = [
  "num-traits 0.2.16",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen",
- "starknet-curve",
- "starknet-ff",
+ "starknet-crypto-codegen 0.3.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-curve 0.4.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
+dependencies = [
+ "starknet-curve 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2963,9 +3001,18 @@ name = "starknet-crypto-codegen"
 version = "0.3.2"
 source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
- "starknet-curve",
- "starknet-ff",
- "syn 2.0.28",
+ "starknet-curve 0.4.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
+dependencies = [
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2973,7 +3020,19 @@ name = "starknet-curve"
 version = "0.4.0"
 source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
- "starknet-ff",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
+dependencies = [
+ "ark-ff",
+ "crypto-bigint",
+ "getrandom",
+ "hex",
 ]
 
 [[package]]
@@ -2996,7 +3055,7 @@ version = "0.1.4"
 source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "starknet-core",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3029,7 +3088,7 @@ dependencies = [
  "eth-keystore",
  "rand",
  "starknet-core",
- "starknet-crypto",
+ "starknet-crypto 0.6.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "thiserror",
 ]
 
@@ -3077,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3127,22 +3186,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3236,7 +3295,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3265,32 +3324,43 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3349,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995483205de764db1185c9461a000fff73fa4b9ee2bbe4c8b4027a94692700fe"
+checksum = "d8f0f68e58d297ba8b22b8b5a96a87b863ba6bb46aaf51e19a4b02c5a6dd5b7f"
 dependencies = [
  "thiserror",
 ]
@@ -3488,7 +3558,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -3522,7 +3592,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3733,5 +3803,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.41",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 description = "Starkli (/ˈstɑːrklaɪ/), a blazing fast CLI tool for Starknet powered by starknet-rs"
 
 [dependencies]
-anyhow = "1.0.71"
+anyhow = "1.0.75"
 async-trait = "0.1.68"
 auto_impl = "1.1.0"
 bigdecimal = "0.4.1"
-cairo-starknet-2-1-0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v2.1.0" }
+cairo-starknet-2-1-0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v2.4.0" }
 chrono = "0.4.26"
 clap = { version = "4.3.8", features = ["derive", "env", "string"] }
 clap_complete = "4.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ anyhow = "1.0.75"
 async-trait = "0.1.68"
 auto_impl = "1.1.0"
 bigdecimal = "0.4.1"
-cairo-starknet-2-1-0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v2.4.0" }
+cairo-starknet-2-1-0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v2.1.0" }
+cairo-starknet-2-4-0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v2.4.0" }
 chrono = "0.4.26"
 clap = { version = "4.3.8", features = ["derive", "env", "string"] }
 clap_complete = "4.3.1"

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -10,6 +10,10 @@ use cairo_starknet_2_1_0::{
     casm_contract_class::CasmContractClass as Cairo210CasmClass,
     contract_class::ContractClass as Cairo210Class,
 };
+use cairo_starknet_2_4_0::{
+    casm_contract_class::CasmContractClass as Cairo240CasmClass,
+    contract_class::ContractClass as Cairo240Class,
+};
 use clap::{builder::PossibleValue, ValueEnum};
 use starknet::core::types::{
     contract::{CompiledClass, SierraClass},
@@ -30,6 +34,7 @@ pub struct CompilerBinary {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompilerVersion {
     V2_1_0,
+    V2_4_0,
 }
 
 impl BuiltInCompiler {
@@ -54,6 +59,16 @@ impl BuiltInCompiler {
                 // TODO: implement the `validate_compatible_sierra_version` call
 
                 let casm_contract = Cairo210CasmClass::from_contract_class(contract_class, false)?;
+
+                serde_json::to_string(&casm_contract)?
+            }
+            CompilerVersion::V2_4_0 => {
+                // TODO: directly convert type without going through JSON
+                let contract_class: Cairo240Class = serde_json::from_str(&sierra_class_json)?;
+
+                // TODO: implement the `validate_compatible_sierra_version` call
+
+                let casm_contract = Cairo240CasmClass::from_contract_class(contract_class, false)?;
 
                 serde_json::to_string(&casm_contract)?
             }
@@ -117,12 +132,13 @@ impl Default for CompilerVersion {
 
 impl ValueEnum for CompilerVersion {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::V2_1_0]
+        &[Self::V2_1_0, Self::V2_4_0]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
         match self {
             Self::V2_1_0 => Some(PossibleValue::new("2.1.0").alias("v2.1.0")),
+            Self::V2_4_0 => Some(PossibleValue::new("2.4.0").alias("v2.4.0")),
         }
     }
 }
@@ -133,6 +149,7 @@ impl FromStr for CompilerVersion {
     fn from_str(s: &str) -> Result<Self> {
         match s {
             "2.1.0" | "v2.1.0" => Ok(Self::V2_1_0),
+            "2.4.0" | "v2.4.0" => Ok(Self::V2_4_0),
             _ => Err(anyhow::anyhow!("unknown version: {}", s)),
         }
     }
@@ -142,6 +159,7 @@ impl Display for CompilerVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CompilerVersion::V2_1_0 => write!(f, "2.1.0"),
+            CompilerVersion::V2_4_0 => write!(f, "2.4.0"),
         }
     }
 }


### PR DESCRIPTION
To declare cairo `2.4.0` contract, in some scenario on Sierra to Casm compilation (especially with components) this may occur:
```
Error: #993: Inconsistent references annotations.
```
To solve this issue, this PR introduces the version `2.4.0` for `cairo-starknet` to support the latest features.

The `auto-version` is still on `2.1.0` for all the networks as the `2.4.0` should land testnet shortly.

The bump of `anyhow` was a dependency bump needed by `cairo-starknet-2-4-0`.