### PR TITLE
Save salt config info

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -267,6 +267,8 @@ pub struct DeployedStatus {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     #[serde_as(as = "UfeHex")]
+    pub salt: FieldElement,
+    #[serde_as(as = "UfeHex")]
     pub address: FieldElement,
 }
 

--- a/src/subcommands/account/deploy.rs
+++ b/src/subcommands/account/deploy.rs
@@ -298,6 +298,7 @@ impl Deploy {
 
         account.deployment = DeploymentStatus::Deployed(DeployedStatus {
             class_hash: undeployed_status.class_hash,
+            salt: undeployed_status.salt,
             address: target_deployment_address,
         });
 


### PR DESCRIPTION
@xJonathanLEI 
Hi~, After successfully depleyed contract, need to save the salt value used to calculate the contract address.