### PR TITLE
feat: support new Argent contract class hash

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -20,7 +20,7 @@ use crate::signer::{AnySigner, SignerArgs, SignerResolutionTask};
 
 const BRAAVOS_SIGNER_TYPE_STARK: Felt = Felt::ONE;
 
-pub const KNOWN_ACCOUNT_CLASSES: [KnownAccountClass; 17] = [
+pub const KNOWN_ACCOUNT_CLASSES: [KnownAccountClass; 18] = [
     KnownAccountClass {
         class_hash: felt!("0x048dd59fabc729a5db3afdf649ecaf388e931647ab2f53ca3c6183fa480aa292"),
         variant: AccountVariantType::OpenZeppelinLegacy,
@@ -60,6 +60,11 @@ pub const KNOWN_ACCOUNT_CLASSES: [KnownAccountClass; 17] = [
         class_hash: felt!("0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b"),
         variant: AccountVariantType::Argent,
         description: "Argent X official account (as of 5.13.1)",
+    },
+    KnownAccountClass {
+        class_hash: felt!("0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f"),
+        variant: AccountVariantType::Argent,
+        description: "Argent X official account (as of 5.16.3) compiled with cairo v2.6.3",
     },
     KnownAccountClass {
         class_hash: felt!("0x04c6d6cf894f8bc96bb9c525e6853e5483177841f7388f74a46cfda6f028c755"),

--- a/src/subcommands/account/argent/init.rs
+++ b/src/subcommands/account/argent/init.rs
@@ -17,9 +17,9 @@ use crate::{
     signer::SignerArgs,
 };
 
-/// Official hashes used as of extension version 5.13.1
+/// Official hashes used as of extension version 5.16.3 compiled with cairo v2.6.3
 const ARGENT_CLASS_HASH: Felt =
-    felt!("0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b");
+    felt!("0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f");
 
 #[derive(Debug, Parser)]
 pub struct Init {


### PR DESCRIPTION
- Support new Argent contract class hash https://starkscan.co/class/0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f

- Support for fetching the new account contract. `account init` now uses the new hash too.